### PR TITLE
Test on Python 3.13 and 3.14 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Text Processing",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Summary

The CI matrix ran `3.8`–`3.12`, but `pyproject.toml` declares `requires-python = ">=3.8"` and the two current stable CPython releases were shipping untested:

- **3.13** — released Oct 2024
- **3.14** — released Oct 2025

This adds both to the test matrix and to the PyPI classifiers, closing the gap between what's declared and what's verified.

## Notes

- Pure-Python, zero-dependency library; the full suite passes on 3.14 unchanged, so each added row is nearly free.
- The matrix still includes 3.8 and 3.9, which are past end-of-life. If you'd prefer to drop them and raise `requires-python`, that's a small follow-up — left as-is here to match the current declared support.

## Test plan

- [x] `pytest tests/` passes locally on Python 3.14 (48 passed)
- [ ] CI matrix goes green on 3.8–3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
