### PR TITLE
Speed up subset construction (NFA -> DFA)

### DIFF
--- a/regex2dfa/nfa.py
+++ b/regex2dfa/nfa.py
@@ -49,16 +49,21 @@ class NFA:
         """Compute epsilon closure of a set of states."""
         closure = set(states)
         stack = list(states)
-        
+        nfa_states = self.states
+
         while stack:
             state = stack.pop()
-            if state in self.states:
-                eps_targets = self.states[state].transitions.get(EPSILON, set())
-                for target in eps_targets:
-                    if target not in closure:
-                        closure.add(target)
-                        stack.append(target)
-        
+            st = nfa_states.get(state)
+            if st is None:
+                continue
+            eps_targets = st.transitions.get(EPSILON)
+            if not eps_targets:
+                continue
+            for target in eps_targets:
+                if target not in closure:
+                    closure.add(target)
+                    stack.append(target)
+
         return closure
     
     def move(self, states: Set[int], char: int) -> Set[int]:

--- a/regex2dfa/subset.py
+++ b/regex2dfa/subset.py
@@ -2,7 +2,8 @@
 Subset construction - converts NFA to DFA using the powerset method.
 """
 
-from typing import Set, Dict, FrozenSet
+from collections import deque
+from typing import Dict, FrozenSet, Set
 
 from .nfa import NFA, EPSILON
 from .dfa import DFA
@@ -11,57 +12,61 @@ from .dfa import DFA
 def nfa_to_dfa(nfa: NFA) -> DFA:
     """
     Convert an NFA to a DFA using subset construction.
-    
+
     Each DFA state represents a set of NFA states.
     We use BFS to explore all reachable DFA states.
     """
     dfa = DFA()
-    
+    nfa_states = nfa.states
+    accept = nfa.accept
+    closure = nfa.epsilon_closure
+
     # Map from frozen set of NFA states to DFA state id
     state_map: Dict[FrozenSet[int], int] = {}
-    
-    # Get all characters used in the NFA (excluding epsilon)
-    alphabet: Set[int] = set()
-    for state in nfa.states.values():
-        for char in state.transitions.keys():
-            if char != EPSILON:
-                alphabet.add(char)
-    
+
     # Start with epsilon closure of NFA start state
-    start_set = frozenset(nfa.epsilon_closure({nfa.start}))
-    is_accept = nfa.accept in start_set
-    
-    start_id = dfa.new_state(is_accept)
+    start_set = frozenset(closure({nfa.start}))
+
+    start_id = dfa.new_state(accept in start_set)
     dfa.start = start_id
     state_map[start_set] = start_id
-    
+
     # BFS to explore all reachable DFA states
-    worklist = [start_set]
-    
+    worklist: deque = deque((start_set,))
+
     while worklist:
-        current_set = worklist.pop(0)
+        current_set = worklist.popleft()
         current_id = state_map[current_set]
-        
-        # For each character in the alphabet
-        for char in alphabet:
-            # Compute the set of NFA states reachable on this character
-            move_set = nfa.move(current_set, char)
-            if not move_set:
+
+        # Gather every non-epsilon transition out of the states in this set in a
+        # single pass, grouped by character. This visits only characters that
+        # actually occur, instead of scanning the whole alphabet per state.
+        moves: Dict[int, Set[int]] = {}
+        for state in current_set:
+            st = nfa_states.get(state)
+            if st is None:
                 continue
-            
-            # Take epsilon closure
-            next_set = frozenset(nfa.epsilon_closure(move_set))
-            
+            for char, targets in st.transitions.items():
+                if char == EPSILON:
+                    continue
+                group = moves.get(char)
+                if group is None:
+                    moves[char] = set(targets)
+                else:
+                    group |= targets
+
+        for char, move_set in moves.items():
+            # Take epsilon closure of the move set to form the next DFA state.
+            next_set = frozenset(closure(move_set))
+
             # Check if this DFA state already exists
-            if next_set not in state_map:
-                is_accept = nfa.accept in next_set
-                next_id = dfa.new_state(is_accept)
+            next_id = state_map.get(next_set)
+            if next_id is None:
+                next_id = dfa.new_state(accept in next_set)
                 state_map[next_set] = next_id
                 worklist.append(next_set)
-            else:
-                next_id = state_map[next_set]
-            
+
             # Add transition
             dfa.add_transition(current_id, char, next_id)
-    
+
     return dfa


### PR DESCRIPTION
## What

Two changes on the NFA→DFA hot path (`regex2dfa/subset.py` + `regex2dfa/nfa.py`):

1. **`subset.py`** — The old loop iterated the whole NFA alphabet and called `nfa.move()` once per character per DFA state set. On large alphabets (e.g. `.` = 256 chars) that scans every state for a transition that usually doesn't exist. Now each state set's outgoing transitions are gathered in a **single pass grouped by character**, visiting only characters that actually occur. Also swaps the BFS worklist from a `list` (`pop(0)` is O(n)) to a `collections.deque`.
2. **`nfa.py`** — `epsilon_closure` no longer allocates a throwaway empty `set()` on every lookup miss (`.get(EPSILON)` instead of `.get(EPSILON, set())`).

## Correctness

Output is byte-identical. Verified:

- All 48 existing tests pass
- **0 differences** vs `origin/master` across thousands of random + generated patterns

## Before / after benchmark

Method: `nfa_to_dfa` timed **old (`origin/master`) vs new in one process, interleaved**, best-of across windows, Python 3.14, over a range of pattern shapes.

| pattern | nfa→dfa states | before | after | speedup |
|---|---|--:|--:|--:|
| `the_quick_brown_fox_jumps` | 50→26 | 141.7 µs | 28.5 µs | **4.97×** |
| `(cat\|dog\|bird\|fish\|snake)` | 46→20 | 110.4 µs | 25.6 µs | 4.31× |
| `\d+\w*` | 8→4 | 249.2 µs | 126.9 µs | 1.96× |
| `.*` | 4→2 | 475.9 µs | 267.3 µs | 1.78× |
| `[^0-9]+` | 4→2 | 436.7 µs | 260.6 µs | 1.68× |
| `(w0\|…\|w9)` | 58→12 | 120.1 µs | 30.8 µs | 3.90× |
| `(w0\|…\|w99)` | 778→102 | 5.72 ms | 1.42 ms | 4.04× |
| `a`×500 | 1000→501 | 625.2 µs | 581.9 µs | 1.07× |
| `(a\|b)*`×32 | 256→3 | 349.1 µs | 260.8 µs | 1.34× |
| `.`×8 | 16→9 | 1.46 ms | 904.8 µs | 1.61× |
| `.`×32 | 64→33 | 5.88 ms | 3.79 ms | 1.55× |
| **total (29-pattern corpus)** | | **22.6 ms** | **11.5 ms** | **1.98×** |

Biggest wins are alternation/literal patterns (many NFA states, sparse per-state transitions), where the old whole-alphabet `move()` scan was most wasteful. Every pattern improves; the smallest gains are long single-char concatenations (already dense/sparse-balanced).

Independent of the other two perf PRs (minimization, formatter) — touches only `subset.py` and `nfa.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
