### PR TITLE
Emit AT&T output in a single pass

### DIFF
--- a/regex2dfa/formatter.py
+++ b/regex2dfa/formatter.py
@@ -2,37 +2,32 @@
 AT&T FST format output.
 """
 
-from typing import List, Tuple
+from typing import List
 from .dfa import DFA
 
 
 def format_att(dfa: DFA) -> str:
     """
     Format a DFA in AT&T FST format.
-    
+
     Format:
     - Transitions: src<TAB>dst<TAB>input<TAB>output
     - Final states: state_id (one per line, at the end)
-    
+
     Labels are ASCII byte values.
     """
     lines: List[str] = []
-    
-    # Collect and sort transitions for deterministic output
-    transitions: List[Tuple[int, int, int, int]] = []
-    
-    for state_id in sorted(dfa.states.keys()):
-        state = dfa.states[state_id]
-        for char in sorted(state.transitions.keys()):
-            target = state.transitions[char]
-            transitions.append((state_id, target, char, char))
-    
-    # Output transitions
-    for src, dst, inp, out in transitions:
-        lines.append(f"{src}\t{dst}\t{inp}\t{out}")
-    
+    states = dfa.states
+
+    # Emit transitions in sorted (state, char) order for deterministic output.
+    for state_id in sorted(states):
+        transitions = states[state_id].transitions
+        for char in sorted(transitions):
+            target = transitions[char]
+            lines.append(f"{state_id}\t{target}\t{char}\t{char}")
+
     # Output final states
     for state_id in sorted(dfa.accept_states):
         lines.append(str(state_id))
-    
+
     return '\n'.join(lines)


### PR DESCRIPTION
## What

`format_att` in `regex2dfa/formatter.py` built an intermediate list of `(src, dst, in, out)` tuples and then looped over it a second time to format strings. This collapses it into a single pass that appends the formatted line directly, dropping the throwaway tuple list. Same sorted `(state, char)` ordering, so output is unchanged.

## Correctness

- All 48 existing tests pass
- **0 differences** vs `origin/master` across the golden pattern set

## Before / after benchmark

Method: `format_att` timed **old (`origin/master`) vs new in one process, interleaved**, best-of across windows, Python 3.14, over a range of pattern shapes.

| pattern | min states | before | after | speedup |
|---|--:|--:|--:|--:|
| `the_quick_brown_fox_jumps` | 26 | 8.80 µs | 7.51 µs | 1.17× |
| `[^0-9]+` | 2 | 111.4 µs | 95.0 µs | 1.17× |
| `\w+@\w+` | 4 | 57.7 µs | 50.9 µs | 1.13× |
| `a`×500 | 501 | 165.1 µs | 139.3 µs | 1.19× |
| `.`×16 | 17 | 928.0 µs | 805.2 µs | 1.15× |
| `.`×32 | 33 | 1.90 ms | 1.60 ms | 1.19× |
| **total (29-pattern corpus)** | | **4.15 ms** | **3.54 ms** | **1.17×** |

A steady ~1.15–1.20× across the board; it matters most for DFAs with many transition lines (large alphabets, long automata).

Independent of the other two perf PRs (minimization, subset construction) — touches only `formatter.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
