### PR TITLE
Security hardening: CodeQL, Dependabot, SECURITY.md, pinned actions, least-privilege perms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Python dependencies (pip ecosystem — pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions used in .github/workflows/ (grouped into a single PR)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
@@ -16,10 +19,10 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '27 4 * * 1'  # Weekly: Mondays at 04:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # Upload CodeQL results
+      actions: read           # Read workflow run metadata (required for private repos)
+      contents: read          # Checkout
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,16 +4,19 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -24,7 +27,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -41,10 +44,10 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided only for the latest released version of `regex2dfa`.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public
+issue, pull request, or discussion for security problems.
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab:
+   <https://github.com/kpdyer/regex2dfa/security>
+2. Click **Report a vulnerability** to open a private advisory
+   (direct link: <https://github.com/kpdyer/regex2dfa/security/advisories/new>).
+3. Include as much detail as you can: affected version(s), a description of the
+   issue and its impact, and a minimal reproduction (input regex / steps) if
+   possible.
+
+You can expect an initial acknowledgement within a few days. Once a fix is
+ready, it will be released in a new version and, where appropriate, published as
+a GitHub Security Advisory crediting the reporter.


### PR DESCRIPTION
## In-repo security hardening

Companion to the repo/branch-protection settings applied out-of-band. All changes are config/docs only — no library code touched.

### What's in here

- **CodeQL** (`.github/workflows/codeql.yml`) — CodeQL analysis for **Python** with the `security-extended` query suite, running on push + PR to `master` and on a weekly schedule (Mondays 04:27 UTC). The analyze job has the deterministic check name **`Analyze (Python)`**, scoped to `security-events: write` / `actions: read` / `contents: read`.
- **Dependabot** (`.github/dependabot.yml`) — weekly version updates for:
  - `pip` (the repo's only package ecosystem — `pyproject.toml`)
  - `github-actions`, **grouped** into a single PR
- **SECURITY.md** — supported-versions table + instructions to report privately via GitHub private vulnerability reporting.
- **Pinned actions** — every `uses:` across all workflows is now pinned to a full commit SHA (resolved from its current release tag) with a `# vN` comment:
  | Action | SHA | Tag |
  | --- | --- | --- |
  | `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | v4 |
  | `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5 |
  | `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
  | `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4 |
  | `pypa/gh-action-pypi-publish` | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` | release/v1 |
  | `github/codeql-action/{init,analyze}` | `c4dd10e44af883a891fe31ced449bcb4a6728b9b` | v3 |
- **Least-privilege permissions** — added top-level `permissions: contents: read` to `ci.yml` and `publish.yml`. The `publish-pypi` job **keeps** its `id-token: write` for trusted PyPI publishing.

### Notes

- CI matrix job names are unchanged (`Python 3.8` … `Python 3.14`), so existing required status checks keep matching.
- After this merges (or once CodeQL first runs on this PR), `Analyze (Python)` is added to the required status checks on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
