### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "regex2dfa"
-version = "0.2.1"
+version = "0.2.2"
 description = "Convert regular expressions to minimized DFAs in AT&T FST format"
 readme = "README_PYPI.md"
 license = "MIT"

--- a/regex2dfa/__init__.py
+++ b/regex2dfa/__init__.py
@@ -12,7 +12,7 @@ from .subset import nfa_to_dfa
 from .hopcroft import minimize_dfa
 from .formatter import format_att
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __all__ = [
     "regex2dfa",
     "Regex2DFA",


### PR DESCRIPTION
Bumps the package version from 0.2.1 to 0.2.2 in `pyproject.toml` and `regex2dfa/__init__.py` ahead of a PyPI release.

## Changes since v0.2.1
- Fix incorrect DFA minimization (correctness)
- Speed up DFA minimization with proper Hopcroft refinement
- Speed up subset construction (NFA → DFA)
- Emit AT&T output in a single pass
- Test on Python 3.13 and 3.14 in CI
- Add `benchmark.py`

No public API changes. All 48 tests pass.

Merging this and publishing a `v0.2.2` GitHub release triggers the Publish to PyPI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)