### PR TITLE
Drop EOL Python support (3.8, 3.9); require >=3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/kpdyer/regex2dfa/actions/workflows/ci.yml/badge.svg)](https://github.com/kpdyer/regex2dfa/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/regex2dfa.svg)](https://pypi.org/project/regex2dfa/)
-[![Python 3.8+](https://img.shields.io/badge/Python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Convert regular expressions to minimized DFAs in AT&T FST format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "regex2dfa"
-version = "0.2.2"
+version = "0.3.0"
 description = "Convert regular expressions to minimized DFAs in AT&T FST format"
 readme = "README_PYPI.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Kevin P. Dyer" }
 ]
@@ -18,8 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

Python 3.8 (EOL Oct 2024) and 3.9 (EOL Oct 2025) are past end-of-life as of today, so this drops them and sets the new minimum to **3.10** (supported until Oct 2026).

## Changes

- **pyproject.toml** — `requires-python = ">=3.10"`, removed the 3.8/3.9 classifiers, bumped version `0.2.2` → `0.3.0`
- **.github/workflows/ci.yml** — test matrix trimmed to `['3.10', '3.11', '3.12', '3.13', '3.14']`
- **README.md** — badge updated to "Python 3.10+"

`publish.yml` (pins 3.12 for building) and `benchmark.py` (only prints the running version) needed no changes.

## Versioning

Bumped to `0.3.0` since dropping supported interpreters is a breaking change for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)